### PR TITLE
Fix WDT Reset Bug

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -535,7 +535,7 @@
   #define PUMP_140_MAX_FLOW           (280)
 
   // Microstepping setting for all motor drives connected to extrusion pumps
-  #define E_MICROSTEPS              (16)
+  #define E_MICROSTEPS              (4)
 
   // External Pump
   #define EXT_VPUMP                 PUMP_50
@@ -578,8 +578,7 @@
     #define E_MAX_FLOW              PUMP_50_MAX_FLOW
   #elif EXT_VPUMP == PUMP_50_GEARED
     #define E_STEPS_PER_UL          PUMP_50_GEARED_STEPS_UL
-    // temporarily limit 50_geared pump to 24 uL/s
-    #define E_MAX_FLOW              PUMP_12_MAX_FLOW //PUMP_50_GEARED_MAX_FLOW
+    #define E_MAX_FLOW              PUMP_50_GEARED_MAX_FLOW
   #elif EXT_VPUMP == PUMP_140
     #define E_STEPS_PER_UL          PUMP_140_STEPS_UL
     // temporarily limit 140 pump to 100 uL/s, driver not strong enough

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -408,7 +408,7 @@
 #define MINIMUM_PLANNER_SPEED 0.05 // (mm/sec)
 
 // Microstep setting (Only functional when stepper driver microstep pins are connected to MCU.
-#define MICROSTEP_MODES {16,16,16,16,16} // [1,2,4,8,16]
+#define MICROSTEP_MODES {4,4,4,4,4} // [1,2,4,8,16]
 
 /**
  *  @section  stepper motor current


### PR DESCRIPTION
# Fix Watchdog Timer Reset Bug
* When high step rates are commanded (for example, with geared stepper motors, or with 32x microstepping), the stepper ISR occupies enough time that the WDT cannot kicked in time.
* Microstepping was set from x16 to x4
* Can still get 0.015 uL per step with 12uL/rev pump
* Can still get 0.0625 uL per step with 50 uL/rev pump
* Can still get 0.175 uL per step with 140 uL/rev pump