### PR TITLE
4x max pump flowrates

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -529,10 +529,10 @@
    * pump.
    *
    */
-  #define PUMP_12_MAX_FLOW            (24)
-  #define PUMP_50_MAX_FLOW            (100)
+  #define PUMP_12_MAX_FLOW            (24 * 4)
+  #define PUMP_50_MAX_FLOW            (100 * 4)
   #define PUMP_50_GEARED_MAX_FLOW     PUMP_50_MAX_FLOW
-  #define PUMP_140_MAX_FLOW           (280)
+  #define PUMP_140_MAX_FLOW           (280 * 4)
 
   // Microstepping setting for all motor drives connected to extrusion pumps
   #define E_MICROSTEPS              (4)


### PR DESCRIPTION
# 4X Max Pump Flowrates
* Maximum pump flowrates were multiplied by four, so that all pumps can be on at the same time at max flow rate.
* A proper implementation of this (i.e. using pump ratio) is coming soon (when I find the giant pot o' gold... I mean time)
* In the meantime, don't exceed 120 rpm on a single pump!